### PR TITLE
Fix free null ptr in uefi_file.c

### DIFF
--- a/uefi-driver/uefi_file.c
+++ b/uefi-driver/uefi_file.c
@@ -192,7 +192,8 @@ out:
 		/* NB: This call only destroys the file if RefCount = 0 */
 		NtfsFreeFile(NewFile);
 	}
-	FreePool(Path);
+	if(Path != NULL)
+		FreePool(Path);
 	return Status;
 }
 


### PR DESCRIPTION
Hi @pbatard 

I am using the Linux platform to generate OVMF image with this ntfs-3g driver.

I have successfully built the OVMF.fd image, but when I try to enter the EFI Shell, it gets stuck at the loading screen, only display a white cursor.

![2023-05-30 203458](https://github.com/pbatard/ntfs-3g/assets/41407837/6e54641d-dccc-4ec2-b4e3-4ebf3da3faa7)

I have printed the debug information to the stdio, and it appears as follows:

> ASSERT_EFI_ERROR (Status = Invalid Parameter)
> ASSERT [ntfs] /home/zzh/uefi_pj/edk3/edk2/MdePkg/Library/UefiMemoryAllocationLib/MemoryAllocationLib.c(821): !(((INTN)(RETURN_STATUS)(Status)) < 0)

After debugging, I found that the issue may be caused by freeing a null pointer in uefi_file.c at line 195. 

Therefore, I added a condition to check for this, and now it has been fixed. The EFI Shell can be accessed normally.